### PR TITLE
Move prettier to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
         "@babel/plugin-syntax-typescript": "^7.21.4",
         "chalk": "^4.1.2",
         "globby": "^11.1.0",
-        "prettier": "^3.0.3",
         "recast": "^0.23.3",
         "ts-node": "^10.9.1",
         "yargs": "^17.7.2"
@@ -39,6 +38,10 @@
     "devDependencies": {
         "@types/babel__core": "^7.20.1",
         "@types/node": "^20.1.4",
+        "prettier": "^3.0.3",
         "typescript": "^5.0.4"
+    },
+    "peerDependencies": {
+        "prettier": "^3"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,6 +1051,8 @@ __metadata:
     ts-node: ^10.9.1
     typescript: ^5.0.4
     yargs: ^17.7.2
+  peerDependencies:
+    prettier: ^3
   bin:
     kodemod: ./dist/index.js
   languageName: unknown
@@ -1142,11 +1144,11 @@ __metadata:
   linkType: hard
 
 "prettier@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "prettier@npm:3.0.3"
+  version: 3.3.3
+  resolution: "prettier@npm:3.3.3"
   bin:
     prettier: bin/prettier.cjs
-  checksum: e10b9af02b281f6c617362ebd2571b1d7fc9fb8a3bd17e371754428cda992e5e8d8b7a046e8f7d3e2da1dcd21aa001e2e3c797402ebb6111b5cd19609dd228e0
+  checksum: bc8604354805acfdde6106852d14b045bb20827ad76a5ffc2455b71a8257f94de93f17f14e463fe844808d2ccc87248364a5691488a3304f1031326e62d9276e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR moves prettier to peerDependencies which will allow users to bring their own version. Otherwise, the resolved version could collide with the user's version.